### PR TITLE
Cleanup of warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ postgresql_database_owner: "{{ postgresql_admin_role }}"
 postgresql_ext_install_contrib: no
 postgresql_ext_install_dev_headers: yes
 
+postgres_shmmax: "300000000"
+postgresql_92: False
+
 postgresql_databases: []
 
 postgresql_roles: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,4 @@
   service:
     name: postgresql
     state: restarted
-  sudo: yes
+  become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,14 +20,14 @@
 
 - name: Drop the existing PostgreSQL cluster
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   when: postgresql_cluster_reset and pgdata_dir_exists.changed
 
 - name: Create a new PostgreSQL cluster with specified encoding and locale
   shell: pg_createcluster --start --locale {{postgresql_locale}} -e {{postgresql_encoding}} -d {{postgresql_data_directory}} {{postgresql_version}} {{postgresql_cluster_name}}
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   when: postgresql_cluster_reset and pgdata_dir_exists.changed
 
 - name: Create the PostgreSQL HBA (Host Based Authentication) configuration file (pg_hba.conf)
@@ -38,7 +38,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_hba_configuration
-  sudo: yes
+  become: yes
 
 - name: Create the PostgreSQL settings configuration file (postgresql.conf)
   template:
@@ -48,7 +48,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_settings_configuration
-  sudo: yes
+  become: yes
 
 - name: Create directory for additional PostgreSQL application configuration files
   file:
@@ -57,11 +57,11 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     mode: 0755
-  sudo: yes
+  become: yes
 
 - name: Restart the PostgreSQL process or service
   service:
     name: postgresql
     state: restarted
-  sudo: yes
+  become: yes
   when: postgresql_hba_configuration.changed or postgresql_settings_configuration.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Set shmmax for postgres
+  sysctl:
+    name: "kernel.shmmax"
+    value: "{{ postgres_shmmax }}"
+    sysctl_set: yes
+    state: present
+    reload: yes
+  when: postgresql_92
+
 - name: Ensure that the postgres data directory exists
   file:
     path: "{{ postgresql_data_directory }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,13 +22,13 @@
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: "{{ postgresql_cluster_reset and pgdata_dir_exists.changed }}"
+  when: postgresql_cluster_reset and pgdata_dir_exists.changed
 
 - name: Create a new PostgreSQL cluster with specified encoding and locale
   shell: pg_createcluster --start --locale {{postgresql_locale}} -e {{postgresql_encoding}} -d {{postgresql_data_directory}} {{postgresql_version}} {{postgresql_cluster_name}}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: "{{ postgresql_cluster_reset and pgdata_dir_exists.changed }}"
+  when: postgresql_cluster_reset and pgdata_dir_exists.changed
 
 - name: Create the PostgreSQL HBA (Host Based Authentication) configuration file (pg_hba.conf)
   template:
@@ -64,4 +64,4 @@
     name: postgresql
     state: restarted
   sudo: yes
-  when: "{{ postgresql_hba_configuration.changed or postgresql_settings_configuration.changed }}"
+  when: postgresql_hba_configuration.changed or postgresql_settings_configuration.changed

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -4,7 +4,7 @@
   service:
     name: postgresql
     state: started
-  sudo: yes
+  become: yes
 
 - name: Create the provided PostgreSQL databases
   postgresql_db:
@@ -17,15 +17,15 @@
     template: "template0"
     state: present
     login_user: "{{ postgresql_admin_role }}"
-  sudo: yes
-  sudo_user: "{{ postgresql_admin_role }}"
+  become: yes
+  become_user: "{{ postgresql_admin_role }}"
   with_items: "{{ postgresql_databases }}"
   when: "{{ postgresql_databases|length > 0 }}"
   ignore_errors: yes
 
 - name: Add the hstore extension to the PostgreSQL databases
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   shell: "psql {{ item.name }} --username {{ postgresql_admin_role }} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: "{{ postgresql_databases }}"
   register: hstore_ext_result
@@ -34,8 +34,8 @@
   when: "{{ item.hstore is defined and item.hstore }}"
 
 - name: Add the uuid-ossp extension to the PostgreSQL databases
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   shell: "psql {{ item.name }} --username {{ postgresql_admin_role }} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: "{{ postgresql_databases }}"
   register: uuid_ext_result

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -20,7 +20,7 @@
   become: yes
   become_user: "{{ postgresql_admin_role }}"
   with_items: "{{ postgresql_databases }}"
-  when: "{{ postgresql_databases|length > 0 }}"
+  when: postgresql_databases|length > 0
   ignore_errors: yes
 
 - name: Add the hstore extension to the PostgreSQL databases
@@ -31,7 +31,7 @@
   register: hstore_ext_result
   failed_when: "{{ hstore_ext_result.rc != 0 and ('already exists, skipping' not in hstore_ext_result.stderr) }}"
   changed_when: "{{ hstore_ext_result.rc == 0 and ('already exists, skipping' not in hstore_ext_result.stderr) }}"
-  when: "{{ item.hstore is defined and item.hstore }}"
+  when: item.hstore is defined and item.hstore
 
 - name: Add the uuid-ossp extension to the PostgreSQL databases
   become: yes
@@ -41,4 +41,4 @@
   register: uuid_ext_result
   failed_when: "{{ uuid_ext_result.rc != 0 and ('already exists, skipping' not in uuid_ext_result.stderr) }}"
   changed_when: "{{ uuid_ext_result.rc == 0 and ('already exists, skipping' not in uuid_ext_result.stderr) }}"
-  when: "{{ item.uuid_ossp is defined and item.uuid_ossp }}"
+  when: item.uuid_ossp is defined and item.uuid_ossp

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -29,8 +29,8 @@
   shell: "psql {{ item.name }} --username {{ postgresql_admin_role }} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: "{{ postgresql_databases }}"
   register: hstore_ext_result
-  failed_when: "{{ hstore_ext_result.rc != 0 and ('already exists, skipping' not in hstore_ext_result.stderr) }}"
-  changed_when: "{{ hstore_ext_result.rc == 0 and ('already exists, skipping' not in hstore_ext_result.stderr) }}"
+  failed_when: hstore_ext_result.rc != 0 and ('already exists, skipping' not in hstore_ext_result.stderr)
+  changed_when: hstore_ext_result.rc == 0 and ('already exists, skipping' not in hstore_ext_result.stderr)
   when: item.hstore is defined and item.hstore
 
 - name: Add the uuid-ossp extension to the PostgreSQL databases
@@ -39,6 +39,6 @@
   shell: "psql {{ item.name }} --username {{ postgresql_admin_role }} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: "{{ postgresql_databases }}"
   register: uuid_ext_result
-  failed_when: "{{ uuid_ext_result.rc != 0 and ('already exists, skipping' not in uuid_ext_result.stderr) }}"
-  changed_when: "{{ uuid_ext_result.rc == 0 and ('already exists, skipping' not in uuid_ext_result.stderr) }}"
+  failed_when: uuid_ext_result.rc != 0 and ('already exists, skipping' not in uuid_ext_result.stderr)
+  changed_when: uuid_ext_result.rc == 0 and ('already exists, skipping' not in uuid_ext_result.stderr)
   when: item.uuid_ossp is defined and item.uuid_ossp

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,4 +2,4 @@
 
 - name: Include Ubuntu-specific PostgreSQL installation tasks
   include: install/Ubuntu.yml
-  when: "{{ ansible_distribution == 'Ubuntu' }}"
+  when: ansible_distribution == 'Ubuntu'

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -5,13 +5,13 @@
     id: "{{ postgresql_apt_key_id }}"
     url: "{{ postgresql_apt_key_url }}"
     state: present
-  sudo: yes
+  become: yes
 
 - name: Add the official PostgreSQL repository to the system
   apt_repository:
     repo: "{{ postgresql_apt_repository }}"
     state: present
-  sudo: yes
+  become: yes
 
 - name: Install PostgreSQL dependency packages
   apt:
@@ -22,7 +22,7 @@
   with_items:
     - python-psycopg2
     - python-pycurl
-  sudo: yes
+  become: yes
 
 - name: Install PostgreSQL packages
   apt:
@@ -36,7 +36,7 @@
     - "postgresql-{{ postgresql_version }}"
     - "postgresql-client-{{ postgresql_version }}"
     - "postgresql-contrib-{{ postgresql_version }}"
-  sudo: yes
+  become: yes
 
 - name: Install the PostgreSQL contrib extensions
   apt:

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -46,8 +46,8 @@
     cache_valid_time: "{{ apt_cache_valid_time | default (3600) }}"
   notify:
     - restart postgresql
-  when: "{{ postgresql_ext_install_contrib }}"
-  sudo: yes
+  when: postgresql_ext_install_contrib
+  become: yes
 
 - name: Install the PostgreSQL development headers
   apt:

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -57,5 +57,5 @@
     cache_valid_time: "{{ apt_cache_valid_time | default (3600) }}"
   notify:
     - restart postgresql
-  when: "{{ postgresql_ext_install_dev_headers }}"
-  sudo: yes
+  when: postgresql_ext_install_dev_headers
+  become: yes

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,7 +4,7 @@
   service:
     name: postgresql
     state: started
-  sudo: yes
+  become: yes
 
 - name: Add the provided roles to the PostgreSQL instance
   postgresql_user:
@@ -13,7 +13,7 @@
     port: "{{ postgresql_port }}"
     state: present
     login_user: "{{ postgresql_admin_role }}"
-  sudo: yes
-  sudo_user: "{{ postgresql_admin_role }}"
+  become: yes
+  become_user: "{{ postgresql_admin_role }}"
   with_items: "{{ postgresql_roles }}"
   when: "{{ postgresql_roles|length > 0 }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -16,4 +16,4 @@
   become: yes
   become_user: "{{ postgresql_admin_role }}"
   with_items: "{{ postgresql_roles }}"
-  when: "{{ postgresql_roles|length > 0 }}"
+  when: postgresql_roles|length > 0

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -13,4 +13,4 @@
   become: yes
   become_user: "{{ postgresql_admin_role }}"
   with_items: "{{ postgresql_role_privileges }}"
-  when: "{{ postgresql_roles|length > 0 }}"
+  when: postgresql_roles|length > 0

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -10,7 +10,7 @@
     login_host: "{{ item.host | default('localhost') }}"
     login_user: "{{ postgresql_admin_role }}"
     role_attr_flags: "{{ item.role_attr_flags | default('') }}"
-  sudo: yes
-  sudo_user: "{{ postgresql_admin_role }}"
+  become: yes
+  become_user: "{{ postgresql_admin_role }}"
   with_items: "{{ postgresql_role_privileges }}"
   when: "{{ postgresql_roles|length > 0 }}"


### PR DESCRIPTION
Addresses both
```
when statements should not include jinja2 templating delimiters such as {{ }} or {% %}...
```
and
```
Instead of sudo/sudo_user, use become/become_user...
```
